### PR TITLE
Add 'start-standalone' function

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -152,10 +152,10 @@ waitInstallComplete = (slug, callback) ->
         statusClient.get "api/applications/", (err, res, apps) ->
             return unless apps?.rows?
             for app in apps.rows
+                console.log slug, app.slug, app.state, app.port
                 if app.slug is slug and app.state is 'installed' and app.port
                     statusClient.host = "http://localhost:#{app.port}/"
                     statusClient.get "", (err, res) ->
-                        console.log res.statusCode
                         if res?.statusCode in [200, 403]
                             callback null, state: 'installed'
                         else


### PR DESCRIPTION
Start-standalone function allows to start an application without controller in a production environment. This function should be executed in application directory.
- Recover manifest (with application permissions)
- Generate a temporary token
- Add/Replace application in database (usefull for cozy stack)
- Reset proxy
- Add environment variables (NAME, TOKEN and NODE_ENV)
- Start application
- When application is stopped (via a Ctrl-C) : 
  - Stop application
  - Remove application from database (usefull for cozy stack)
  - Reset Proxy
