### PR TITLE
[enh] Enable app deployment via Git

### DIFF
--- a/lib/application.coffee
+++ b/lib/application.coffee
@@ -15,7 +15,7 @@ handleError = helpers.handleError
 makeError = helpers.makeError
 getToken = helpers.getToken
 
-appsDir = "/usr/local/cozy/apps/"
+appsDir = "/usr/local/cozy/apps"
 
 # Applications helpers #
 
@@ -153,12 +153,13 @@ install = module.exports.install = (app, options, callback) ->
         unless options.icon?
             setIcon manifest, (icon) ->
                 manifest.icon = icon
-                callback manifest
         else
             manifest.icon = options.icon
 
         if options.local?
             manifest.local = options.local
+
+        callback manifest
 
     path = "api/applications/install"
 
@@ -197,10 +198,11 @@ deploy = module.exports.deploy = (app, options, callback) ->
     unless fs.existsSync appRepo
         return callback new Error "App is not deployable"
 
-    unless fs.existsSync "#{appRepo}/manifest.json" \
-      and manifest = require "#{appRepo}/manifest.json"
-        return callback \
-            new Error "You need a valid `manifest.json` at the root of your \
+    try
+        manifest = require "#{appRepo}/package.json"
+    catch error
+	    return callback \
+            new Error "You need a valid `package.json` at the root of your \
                        repository #{appRepo}"
 
     installOptions =

--- a/lib/application.coffee
+++ b/lib/application.coffee
@@ -15,6 +15,8 @@ handleError = helpers.handleError
 makeError = helpers.makeError
 getToken = helpers.getToken
 
+appsDir = "/usr/local/cozy/apps/"
+
 # Applications helpers #
 
 setIcon = (manifest, callback) ->
@@ -147,10 +149,18 @@ install = module.exports.install = (app, options, callback) ->
 
         if options.branch?
             manifest.branch = options.branch
-        path = "api/applications/install"
-        setIcon manifest, (icon) ->
-            manifest.icon = icon
-            callback manifest
+
+        unless options.icon?
+            setIcon manifest, (icon) ->
+                manifest.icon = icon
+                callback manifest
+        else
+            manifest.icon = options.icon
+
+        if options.local?
+            manifest.local = options.local
+
+    path = "api/applications/install"
 
     recoverManifest (manifest) ->
         homeClient.headers['content-type'] = 'application/json'
@@ -158,7 +168,8 @@ install = module.exports.install = (app, options, callback) ->
             if err or body.error
                 if err?.code is 'ECONNREFUSED'
                     err = makeError msgHomeNotStarted(app), null
-                else if body and body.message and body.message.indexOf('Not Found') isnt -1
+                else if body and body.message \
+                  and body.message.indexOf('Not Found') isnt -1
                     err = makeError msgRepoGit(app), null
                 else
                     err = makeError err, body
@@ -173,6 +184,33 @@ install = module.exports.install = (app, options, callback) ->
                         callback makeError(msgLongInstall(app), null)
                     else
                         callback makeError(msgInstallFailed(app), null)
+
+
+# If <app> is already installed in /usr/local/cozy/apps, we want to deploy it
+# without having to fetch anything on a remote Git repository.
+deploy = module.exports.deploy = (app, options, callback) ->
+    unless app.match /^[a-zA-Z0-9-]{2,30}$/
+        return callback new Error "Invalid app name"
+
+    appRepo = "#{appsDir}/#{app}"
+
+    unless fs.existsSync appRepo
+        return callback new Error "App is not deployable"
+
+    unless fs.existsSync "#{appRepo}/manifest.json" \
+      and manifest = require "#{appRepo}/manifest.json"
+        return callback \
+            new Error "You need a valid `manifest.json` at the root of your \
+                       repository #{appRepo}"
+
+    installOptions =
+        local: true
+        repo: "#{appRepo}"
+
+    if options.branch?
+        installOptions.branch = options.branch
+
+    install app, installOptions, callback
 
 
 # Uninstall application <app>

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -21,6 +21,8 @@ ControllerClient = require("cozy-clients").ControllerClient
 
 # Read Controller auth token from token file located in /etc/cozy/stack.token .
 readToken = (file) ->
+    if process.env.TOKEN?
+        return process.env.TOKEN
     try
         token = fs.readFileSync file, 'utf8'
         token = token.split('\n')[0]

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -59,6 +59,26 @@ program
                 log.info "#{app} was successfully installed."
 
 
+# Deploy
+#
+program
+    .command("deploy <app> ")
+    .description("Deploy an application")
+    .option('-b, --branch <branch>', 'Use specific branch')
+    .action (app, options) ->
+        log.info "Deploying #{app}..."
+        if app in ['data-system', 'home', 'proxy']
+            return logError null, "You cannot deploy a stack application"
+        else
+            deploy = application.deploy
+
+        deploy app, options, (err) ->
+            if err?
+                logError err, "Deployment failed for #{app}."
+            else
+                log.info "#{app} was successfully deployed."
+
+
 # Install cozy stack (home, ds, proxy)
 program
     .command("install-cozy-stack")


### PR DESCRIPTION
## Idea

Being able to `git push` to the proxy and deploy an app this way.

```
$ git remote add cozy https://mycozy.cozycloud.cc/repo/myapp
$ git push cozy master
Username for 'https://mycozy.cozycloud.cc': 
Password for 'https://my@email.org@mycozy.cozycloud.cc': 
remote: Counting objects: 75, done.
remote: Compressing objects: 100% (53/53), done.
remote: Total 62 (delta 27), reused 44 (delta 9)
remote: 
remote: info - Deploying 'myapp'
remote: info - Application 'myapp' has been deployed
remote:
Unpacking objects: 100% (62/62), done.
To https://mycozy.cozycloud.cc/repo/myapp
* [new branch]      master     -> cozy/master
```

## Details for cozy-monitor
The monitor is modified to handle a new action `cozy-monitor deploy` which is called during the `post-update` Git hook. It deploys an app from a local git repository without checking it out.

To merge along with:
* https://github.com/cozy/cozy-home/pull/343
* https://github.com/cozy/cozy-controller/pull/58
* https://github.com/cozy/cozy-proxy/pull/118

**It lacks of test for now, please keep this PR open**