### PR TITLE
Add timeout option for installation and fix start-standalone

### DIFF
--- a/lib/application.coffee
+++ b/lib/application.coffee
@@ -482,8 +482,8 @@ module.exports.startStandalone = (port, callback) ->
                 else
                     # Add environment varaible.
                     log.info "Start application..."
-                    process.env.TOKEN = manifest.password
-                    process.env.NAME = manifest.slug
+                    process.env.TOKEN = access.password
+                    process.env.NAME = access.slug
                     process.env.NODE_ENV = "production"
                     process.env.PORT = port
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -42,6 +42,7 @@ program
     .option('-r, --repo <repo>', 'Use specific repo')
     .option('-b, --branch <branch>', 'Use specific branch')
     .option('-d, --displayName <displayName>', 'Display specific name')
+    .option('-t , --timeout <timeout>', 'Configure timeout (in millisecond), -t false to remove timeout)')
     .action (app, options) ->
         if options.repo and options.repo.indexOf('.git') is -1
             options.repo = options.repo + '.git'


### PR DESCRIPTION
 * Allow to define timeout for installation : refs #85 

Use a timeout of 1000 milliseconds:
``` cozy-monitor install <app> -t 1000 ```
Remove timeout:
``` cozy-monitor install <app> -t false```

* Fix start-standalone function : refs #89 