### PR TITLE
Fix error-safe option was only showing one error

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -75,11 +75,13 @@ module.exports.makeError = (err, body) ->
         else if body.error
             return new Error(body.error)
 
-module.exports.logError = (err, msg) ->
+module.exports.logError = (err, msg, doExit = true) ->
     log.error "An error occured:"
     log.error msg if msg?
     log.raw err
-    process.exit(1)
+
+    if doExit
+        process.exit(1)
 
 module.exports.handleError = (err, body, msg) ->
     log.error "An error occured:"

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -377,13 +377,12 @@ program
                         else
                             callback()
                 , (err) ->
-
                     # If the errorSafe option is enabled and there is at least
                     # one error, display them.
                     if options['errorSafe'] and errors.length > 0
                         for err in errors
                             logError err, "An application has not been " + \
-                                          "reinstalled."
+                                          "reinstalled.", false
 
                         # Command is errored only if all installation have
                         # failed.


### PR DESCRIPTION
`logError` always exits process. I changed the behaviour so it's still the default behaviour, but it can be prevented with a flag.

That allows me to fix a bug where reinstall-missing-app with flag --error-safe would not display all errors, but just one.

This is not blocking for the infrastructure team, but still an improvement.