### PR TITLE
Fix space encoding in couchdb document ids

### DIFF
--- a/src/export.coffee
+++ b/src/export.coffee
@@ -84,7 +84,7 @@ getContent = (couchClient, binaryId, type, callback) ->
 allDocuments = (couchClient, start, forEach, done) ->
     limit = 1000
     u = "cozy/_all_docs?include_docs=true&limit=#{limit}"
-    u += "&skip=1&startkey=\"#{start}\"" if start?
+    u += "&skip=1&startkey=\"#{encodeURIComponent start}\"" if start?
     couchClient.get u, (err, res, body) ->
         if err?
             done err


### PR DESCRIPTION
Not tested. Just a try to fix this error:

```
TypeError: Request path contains unescaped characters.
    at new ClientRequest (_http_client.js:50:11)
    at Object.exports.request (http.js:31:10)
    at playRequest (/usr/lib/node_modules/cozy-monitor/node_modules/request-json-light/main.js:101:29)
    at Object.module.exports.get (/usr/lib/node_modules/cozy-monitor/node_modules/request-json-light/main.js:130:12)
    at JsonClient.get (/usr/lib/node_modules/cozy-monitor/node_modules/request-json-light/main.js:189:27)
    at allDocuments (/usr/lib/node_modules/cozy-monitor/lib/export.js:116:22)
    at /usr/lib/node_modules/cozy-monitor/lib/export.js:127:18
    at /usr/lib/node_modules/cozy-monitor/node_modules/async/lib/async.js:52:16
    at /usr/lib/node_modules/cozy-monitor/node_modules/async/lib/async.js:269:32
    at /usr/lib/node_modules/cozy-monitor/node_modules/async/lib/async.js:44:16
```
